### PR TITLE
Fix too many redirections error

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,1 +1,2 @@
-https://dmclavel.netlify.app/* https://daimlerclavel.com/ 301
+https://dmclavel.netlify.app/ https://daimlerclavel.com/ 301!
+https://www.daimlerclavel.com/ https://daimlerclavel.com/ 301!


### PR DESCRIPTION
- Use `301!` instead of `301`
- Add redirect from www to non-www site